### PR TITLE
Remove o app bootstrap_paginate e implementa a paginação manualmente

### DIFF
--- a/apps/core/templates/jobs-empresa.html
+++ b/apps/core/templates/jobs-empresa.html
@@ -1,5 +1,4 @@
 {% extends "base.html" %}
-{% load bootstrap_pagination %}
 {%block title%}Jobs disponíveis!{%endblock title%}
 {%block ptitle%}Jobs disponíveis!{%endblock ptitle%}
 {% block content %}
@@ -21,5 +20,27 @@
 </div>
 <hr/>
 {% endfor %}
-{% bootstrap_paginate jobs range=n_pages %}
+<nav aria-label="Page navigation example">
+  <ul class="pagination">
+    {% if jobs.has_previous %}
+    <li class="page-item">
+      <a class="page-link" href="?page={{ jobs.previous_page_number }}" aria-label="Anterior">
+        <span aria-hidden="true">&laquo;</span><span class="sr-only">Anterior</span>
+      </a>
+    </li>
+    {% endif %}
+    {% for page in jobs.paginator.page_range %}
+    <li class="page-item {% if jobs.number == page%}active{% endif %}">
+      <a class="page-link" href="?page={{ page }}">{{ page }}</a>
+    </li>
+    {% endfor %}
+    {% if jobs.has_next %}
+    <li class="page-item">
+      <a class="page-link" href="?page={{ jobs.next_page_number }}" aria-label="Próximo">
+        <span aria-hidden="true">&raquo;</span><span class="sr-only">Próximo</span>
+      </a>
+    </li>
+    {% endif %}
+  </ul>
+</nav>
 {% endblock content %}

--- a/apps/core/views.py
+++ b/apps/core/views.py
@@ -139,9 +139,6 @@ def vagas(request):
 
     context = {
         'jobs': jobs_pag,
-        'pages': paginator.page_range,
-        'actual_page': int(page),
-        'n_pages': int(paginator.num_pages),
         "user":request.user
     }
     return render(request, "jobs-empresa.html", context)

--- a/apps/curriculumdb/templates/cvs.html
+++ b/apps/curriculumdb/templates/cvs.html
@@ -1,5 +1,4 @@
 {% extends "base.html" %}
-{% load bootstrap_pagination %}
 {% block content %}
 <h2 style="margin-top:15px;text-align:center;">Membros do banco de currículos:</h2>
 <style media="screen">
@@ -43,5 +42,27 @@
 </div>
 <hr/>
 {% endfor %}
-{% bootstrap_paginate interessados range=n_pages %}
+<nav aria-label="Page navigation example">
+  <ul class="pagination">
+    {% if interessados.has_previous %}
+    <li class="page-item">
+      <a class="page-link" href="?page={{ interessados.previous_page_number }}" aria-label="Anterior">
+        <span aria-hidden="true">&laquo;</span><span class="sr-only">Anterior</span>
+      </a>
+    </li>
+    {% endif %}
+    {% for page in interessados.paginator.page_range %}
+    <li class="page-item {% if interessados.number == page%}active{% endif %}">
+      <a class="page-link" href="?page={{ page }}">{{ page }}</a>
+    </li>
+    {% endfor %}
+    {% if interessados.has_next %}
+    <li class="page-item">
+      <a class="page-link" href="?page={{ interessados.next_page_number }}" aria-label="Próximo">
+        <span aria-hidden="true">&raquo;</span><span class="sr-only">Próximo</span>
+      </a>
+    </li>
+    {% endif %}
+  </ul>
+</nav>
 {% endblock content %}

--- a/apps/curriculumdb/views.py
+++ b/apps/curriculumdb/views.py
@@ -31,9 +31,6 @@ def lista_de_curriculos(request):
 
     context = {
         'interessados': cv_pag,
-        'pages': paginator.page_range,
-        'actual_page': page,
-        'n_pages': int(paginator.num_pages),
         "user":request.user
     }
 

--- a/apps/jobs/views.py
+++ b/apps/jobs/views.py
@@ -36,9 +36,6 @@ def find_job(request):
 
         context = {
             'jobs': jobs_pag,
-            'pages': paginator.page_range,
-            'actual_page': int(page),
-            'n_pages': int(paginator.num_pages),
             "user":request.user
         }
         return render(request, "jobs.html", context)

--- a/pyjobs/settings.py
+++ b/pyjobs/settings.py
@@ -53,7 +53,6 @@ INSTALLED_APPS = [
     # 'kombu.transport.django',
     # 'djcelery',
     'bootstrap3',
-    'bootstrap_pagination',
 ]
 
 MIDDLEWARE = [

--- a/pyjobs/templates/jobs.html
+++ b/pyjobs/templates/jobs.html
@@ -1,5 +1,4 @@
 {% extends "base.html" %}
-{% load bootstrap_pagination %}
 {%block title%}Jobs disponíveis!{%endblock title%}
 {%block ptitle%}Jobs disponíveis!{%endblock ptitle%}
 {% block content %}
@@ -21,5 +20,27 @@
 </div>
 <hr/>
 {% endfor %}
-{% bootstrap_paginate jobs range=n_pages %}
+<nav aria-label="Page navigation example">
+  <ul class="pagination">
+    {% if jobs.has_previous %}
+    <li class="page-item">
+      <a class="page-link" href="?page={{ jobs.previous_page_number }}" aria-label="Anterior">
+        <span aria-hidden="true">&laquo;</span><span class="sr-only">Anterior</span>
+      </a>
+    </li>
+    {% endif %}
+    {% for page in jobs.paginator.page_range %}
+    <li class="page-item {% if jobs.number == page%}active{% endif %}">
+      <a class="page-link" href="?page={{ page }}">{{ page }}</a>
+    </li>
+    {% endfor %}
+    {% if jobs.has_next %}
+    <li class="page-item">
+      <a class="page-link" href="?page={{ jobs.next_page_number }}" aria-label="Próximo">
+        <span aria-hidden="true">&raquo;</span><span class="sr-only">Próximo</span>
+      </a>
+    </li>
+    {% endif %}
+  </ul>
+</nav>
 {% endblock content %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ dj-static==0.0.6
 Django==1.11.5
 django-autocomplete-light==3.2.10
 django-bootstrap==0.2.4
-django-bootstrap-pagination==1.6.2
 django-bootstrap3==9.0.0
 django-celery==3.2.1
 django-extensions==1.8.1


### PR DESCRIPTION
Fiz a implementação da paginação manualmente sem o uso do módulo bootstrap_paginate, porque esse módulo não está contemplando o bootstrap 4 e a paginação não está sendo apresentada como deveria.