### PR TITLE
Sets python image version to 3.6 and apply Dockerfile best pratices

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,11 @@
-FROM python:3
+FROM python:3.6
 ENV PYTHONUNBUFFERED 1
+
 RUN mkdir /code
+
 WORKDIR /code
-ADD ./pyjobs/* /code/
-ADD requirements.txt /code/
+
+COPY /pyjobs/ /code/
+COPY requirements.txt /code/
+
 RUN pip install -r requirements.txt


### PR DESCRIPTION
Até então o Dockerfile estava configurado para sempre usar a última imagem/versão do python (tag latest), como o  projeto hoje roda com django 1.11 e essa versão não possui total compatibilidade com python 3.7 fixei a versão da imagem para 3.6 e aproveitei para aplicar algumas boas práticas.

https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#add-or-copy  