### PR TITLE
Fix pagination

### DIFF
--- a/pyjobs/core/templates/index.html
+++ b/pyjobs/core/templates/index.html
@@ -131,9 +131,33 @@
                 {% endfor %}
                 <nav style="margin-top:10px;">
                     <ul class="pagination">
-                      {%for page in pages%}
-                        <li class="page-item"><a class="page-link" href="{% url 'index' %}?page={{page}}">{{page}}</a></li>
-                      {%endfor%}
+                        {% if jobs.has_previous %}
+                            <li><a class="page-link" href="?page={{ jobs.previous_page_number }}">Previous<i  class="page-item" aria-hidden="true"></i></a></li>
+                        {% else %}
+                            <li class=" page-link disabled"><span>Previous<i class="page-item" aria-hidden="true"></i></span></li>
+                        {% endif %}
+                        
+                        {% if jobs.number|add:'-4' > 1 %}
+                            <li><a class="page-link" href="?page={{ jobs.number|add:'-5' }}">&hellip;</a></li>
+                        {% endif %}
+                        
+                        {% for i in jobs.paginator.page_range %}
+                            {% if jobs.number == i %}
+                                <li class="page-item active"><span><a class="page-link" href="?page={{ i }}">{{ i }}</a></li>
+                            {% elif i > jobs.number|add:'-5' and i < jobs.number|add:'5' %}
+                                <li><a class="page-link" href="?page={{ i }}">{{ i }}</a></li>
+                            {% endif %}
+                        {% endfor %}
+                        
+                        {% if jobs.paginator.num_pages > jobs.number|add:'4' %}
+                            <li><a class="page-link" href="?page={{ jobs.number|add:'5' }}">&hellip;</a></li>
+                        {% endif %}
+                        
+                        {% if jobs.has_next %}
+                            <li><a class="page-link" href="?page={{ jobs.next_page_number }}">Next<i class="fa fa-chevron-right" aria-hidden="true"></i></a></li>
+                        {% else %}
+                            <li class="page-link disabled"><span>Next<i class="fa fa-chevron-right" aria-hidden="true"></i></span></li>
+                        {% endif %}
                     </ul>
                 </nav>
             </div>

--- a/pyjobs/core/views.py
+++ b/pyjobs/core/views.py
@@ -19,17 +19,33 @@ def index(request):
     # Passing the value to Paginator
     paginator = Paginator(Job.get_publicly_available_jobs(search), 5)
 
-    page = request.GET.get('page')
+    try:
+        page = int(request.GET.get('page', '1'))
+    except:
+        page = 1
+
     try:
         public_jobs_to_display = paginator.page(page)
     except:
         public_jobs_to_display = paginator.page(1)
 
+    # Get the index of the current page
+    index = public_jobs_to_display.number - 1  # edited to something easier without index
+    # This value is maximum index of your pages, so the last page - 1
+    max_index = len(paginator.page_range)
+    # You want a range of 7, so lets calculate where to slice the list
+    start_index = index - 3 if index >= 3 else 0
+    end_index = index + 3 if index <= max_index - 3 else max_index
+    # Get our new page range. In the latest versions of Django page_range returns 
+    # an iterator. Thus pass it to list, to make our slice possible again.
+    page_range = list(paginator.page_range)[start_index:end_index]
+
     context_dict = {
         "publicly_available_jobs": public_jobs_to_display,
         "premium_available_jobs": Job.get_premium_jobs(),
         "new_job_form": JobForm,
-        "pages": paginator.page_range,
+        "jobs": jobs,
+        "page_range": page_range,
         "search": search if search is not None else ''
     }
     return render(request, template_name="index.html", context=context_dict)


### PR DESCRIPTION
Com a grande quantidade de Jobs cadastrados a paginação está ficando muito extença, então a solução é exibe apenas alguns dos números de página por paginação de django, encontrei um exemplo disso no [stackoverflow](https://stackoverflow.com/questions/30864011/display-only-some-of-the-page-numbers-by-django-pagination).