### PR TITLE
Faz o mock do TelegramError da maneira apropriada

### DIFF
--- a/pyjobs/core/tests/test_utils.py
+++ b/pyjobs/core/tests/test_utils.py
@@ -1,11 +1,12 @@
-from django.test import TestCase
 from unittest.mock import patch
+
+from django.test import TestCase
 from telegram import TelegramError
 
 from pyjobs.core.utils import post_telegram_channel
 
-class TelegramPosterTest(TestCase):
 
+class TelegramPosterTest(TestCase):
     def setUp(self):
         self.message = "Hello, World!"
 
@@ -13,33 +14,24 @@ class TelegramPosterTest(TestCase):
     @patch('pyjobs.core.utils.Bot')
     def test_post_message_to_telegram_successfully(self, mocked_bot, mocked_config):
         mocked_config.side_effect = ('my-token', 'my-channel')
-        posted_message = post_telegram_channel(self.message)
-        self.assertEqual(posted_message, (True, 'success'))
-
-    @patch('pyjobs.core.utils.config')
-    @patch('pyjobs.core.utils.Bot')
-    def test_post_telegram_channel(self, mocked_bot, mocked_config):
-        mocked_config.side_effect = ('my-token', 'my-channel')
-
-        assert post_telegram_channel(self.message)[0]
-
+        result, message = post_telegram_channel(self.message)
+        self.assertTrue(result)
+        self.assertEqual(message, 'success')
         mocked_config.assert_any_call('TELEGRAM_TOKEN', default=None)
         mocked_config.assert_any_call('TELEGRAM_CHATID', default=None)
-
         mocked_bot.assert_called_with('my-token')
         mocked_bot.return_value.send_message.assert_called_with(
             chat_id='my-channel',
             text=self.message
         )
 
-
     @patch('pyjobs.core.utils.config')
     @patch('pyjobs.core.utils.Bot')
     def test_post_no_auth_telegram_channel(self, mocked_bot, mocked_config):
         mocked_config.side_effect = (None, None)
-
-        assert post_telegram_channel(self.message) == (False, 'missing_auth_keys')
-
+        result, message = post_telegram_channel(self.message)
+        self.assertFalse(result)
+        self.assertEqual(message, 'missing_auth_keys')
 
     @patch('pyjobs.core.utils.config')
     @patch('pyjobs.core.utils.Bot')

--- a/pyjobs/core/tests/test_utils.py
+++ b/pyjobs/core/tests/test_utils.py
@@ -46,12 +46,14 @@ class TelegramPosterTest(TestCase):
     @patch('pyjobs.core.utils.Bot')
     def test_post_wrong_auth_telegram_channel(self, mocked_bot, mocked_config):
         mocked_config.side_effect = ('my-token', 'my-channel')
-        mocked_bot.side_effect = (TelegramError("error"))
-
-        with self.assertRaises(TelegramError):
-            assert post_telegram_channel(self.message) == (False, 'wrong_auth_keys')
-
-            mocked_config.assert_any_call('TELEGRAM_TOKEN', default=None)
-            mocked_config.assert_any_call('TELEGRAM_CHATID', default=None)
-
-            mocked_bot.assert_called_once_with('my-token')
+        mocked_bot.return_value.send_message.side_effect = TelegramError('error')
+        result, message = post_telegram_channel(self.message)
+        self.assertFalse(result)
+        self.assertEqual(message, 'wrong_auth_keys')
+        mocked_config.assert_any_call('TELEGRAM_TOKEN', default=None)
+        mocked_config.assert_any_call('TELEGRAM_CHATID', default=None)
+        mocked_bot.assert_called_once_with('my-token')
+        mocked_bot.return_value.send_message.assert_called_with(
+            chat_id='my-channel',
+            text=self.message
+        )

--- a/pyjobs/core/tests/test_utils.py
+++ b/pyjobs/core/tests/test_utils.py
@@ -6,8 +6,7 @@ from pyjobs.core.utils import post_telegram_channel
 
 class TelegramPosterTest(TestCase):
 
-    @patch('telegram.Bot')
-    def setUp(self, _mocked_telegram_bot):
+    def setUp(self):
         self.message = "Hello, World!"
 
     @patch('pyjobs.core.utils.config')

--- a/pyjobs/core/utils.py
+++ b/pyjobs/core/utils.py
@@ -8,7 +8,6 @@ def post_telegram_channel(message):
     if telegram_token and chat_id:
         bot = Bot(telegram_token)
         try:
-            bot = Bot(telegram_token)
             bot.send_message(chat_id=chat_id, text=message)
             return True, 'success'
 


### PR DESCRIPTION
O _pull request_ atualmente #104 fazia o _mock_ para simular um erro do `pyjobs.core.utils.Bot.send_message` no objeto errado (`pyjobs.core.utils.Bot`). Esse pull request resolve esse problema com 640fe5f. Como (quase) sempre, recomendo o review _commit_ a _commit_.

A partir disso esse _pull request_ também propõe:

* Remoção de um _mock_ não-utilizado 881432b
* Refatoração dos testes de `TelegramPosterTest` para legibilidade (ao invés de testar tuplas, testar separadamente o resultado com `self.assertTrue` ou `self.assertFalse`, e testar as mensagens com `self.assertEqual`) e3d86ac
* Arruma um bug inofensivo do `utils.py` que instanciava duas vezes um objeto `bot` 
86ebc49 