### PR TITLE
Adiciona testes ao helper do mailchimp e refatora helper

### DIFF
--- a/pyjobs/core/newsletter.py
+++ b/pyjobs/core/newsletter.py
@@ -1,17 +1,22 @@
+from django.conf import settings
 from mailchimp3 import MailChimp
-from decouple import config
+
 
 def subscribe_user_to_chimp(profile):
-    api_key = config("MAILCHIMP_API_KEY", default=None)
-    user_api = config("MAILCHIMP_USERNAME", default=None)
-    list_id = config("MAILCHIMP_LIST_KEY", default=None)
-    if api_key != None:
+    api_key = settings.MAILCHIMP_API_KEY
+    user_api = settings.MAILCHIMP_USERNAME
+    list_id = settings.MAILCHIMP_LIST_KEY
+
+    if not all([api_key, user_api, list_id]):
+        return False
+
+    try:
         client = MailChimp(api_key, user_api)
-        try:
-            client.lists.members.create(list_id, {
-                'status': 'subscribed',
-                'email_address': profile.user.email,
-            })
-        except:
-            pass
-    return False
+        client.lists.members.create(list_id, {
+            'status': 'subscribed',
+            'email_address': profile.user.email,
+        })
+        return True
+
+    except:
+        return False

--- a/pyjobs/settings.py
+++ b/pyjobs/settings.py
@@ -139,3 +139,7 @@ EMAIL_BACKEND = config(
 )
 
 SENDGRID_API_KEY = config('SENDGRID_API_KEY', default=None)
+
+MAILCHIMP_API_KEY = config("MAILCHIMP_API_KEY", default=None)
+MAILCHIMP_USERNAME = config("MAILCHIMP_USERNAME", default=None)
+MAILCHIMP_LIST_KEY = config("MAILCHIMP_LIST_KEY", default=None)


### PR DESCRIPTION
Basicamente este PR ajusta a cobertura de testes do arquivo `newsletter.py` e refatora a função.