### PR TITLE
Block CI if Pipenv.lock is out of date

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
   - ./cc-test-reporter before-build
   - pip install -U pip
   - pip install -U pipenv
-  - pipenv install --dev --system
+  - pipenv install --dev --system --deploy
 before_script:
   - python manage.py migrate
   - python manage.py collectstatic --no-input


### PR DESCRIPTION
The idea is to use the [`--deploy`](https://pipenv.readthedocs.io/en/latest/advanced/#using-pipenv-for-deployments) argument to turn red lights on in the CI if `Pipfile.lock` is out of date. In production, Heroku [already uses this option](https://github.com/heroku/heroku-buildpack-python/blob/master/bin/steps/pipenv#L74).

Given current status of `master` (e846146), and if Travis is configured, this PR is supposed to fail, until changes such as the ones from #131 comes in ; )