### PR TITLE
Fix pagination links 

### DIFF
--- a/pyjobs/core/templates/index.html
+++ b/pyjobs/core/templates/index.html
@@ -2,6 +2,7 @@
 {% load static %}
 {% load humanize %}
 {% load widget_tweaks %}
+{% load core_tags %}
 {%block title%} {{WEBSITE_NAME}} - A Central de Jobs {{WEBSITE_WORKING_LANGUAGE}}
 {%endblock%}
 {%block main%}
@@ -132,7 +133,7 @@
                     <ul class="pagination">
                       {% for page in pages %}
                         <li class="page-item">
-                            <a class="page-link" href="{% url 'index' %}?page={{page}}{% if 'search' in request.GET %}&search={{ request.GET.search }}{% endif %}">{{ page }}</a>
+                            <a class="page-link" href="{% url 'index' %}?{% merge_query_params page=page %}">{{ page }}</a>
                         </li>
                       {% endfor %}
                     </ul>

--- a/pyjobs/core/templatetags/core_tags.py
+++ b/pyjobs/core/templatetags/core_tags.py
@@ -5,7 +5,7 @@ register = template.Library()
 
 @register.simple_tag(takes_context=True)
 def merge_query_params(context, **kwargs):
-    query_params = context['request'].GET.copy()
+    query_params = context["request"].GET.copy()
 
     for k, v in kwargs.items():
         query_params[k] = v

--- a/pyjobs/core/templatetags/core_tags.py
+++ b/pyjobs/core/templatetags/core_tags.py
@@ -1,0 +1,13 @@
+from django import template
+
+register = template.Library()
+
+
+@register.simple_tag(takes_context=True)
+def merge_query_params(context, **kwargs):
+    query_params = context['request'].GET.copy()
+
+    for k, v in kwargs.items():
+        query_params[k] = v
+
+    return query_params.urlencode()

--- a/pyjobs/core/tests/test_templatetags.py
+++ b/pyjobs/core/tests/test_templatetags.py
@@ -1,0 +1,35 @@
+from django.test import SimpleTestCase, RequestFactory
+from django.template import Context, Template
+
+
+class TestMergeQueryParamsTag(SimpleTestCase):
+    def setUp(self):
+        self.rf = RequestFactory()
+
+    def test_add_param(self):
+        request = self.rf.get('/', {'description': 'descricao', 'salary_range': 1})
+        context = Context({'request': request})
+        template = Template(
+            '{% load core_tags %}'
+            '<a class="page-link" href="/?{% merge_query_params page=1 %}">1</a>'
+        )
+        rendered_template = template.render(context)
+
+        self.assertInHTML(
+            '<a class="page-link" href="/?description=descricao&salary_range=1&page=1">1</a>',
+            rendered_template
+        )
+
+    def test_replace_param(self):
+        request = self.rf.get('/', {'description': 'descricao', 'salary_range': 1, 'page': 2})
+        context = Context({'request': request})
+        template = Template(
+            '{% load core_tags %}'
+            '<a class="page-link" href="/?{% merge_query_params page=10 %}">1</a>'
+        )
+        rendered_template = template.render(context)
+
+        self.assertInHTML(
+            '<a class="page-link" href="/?description=descricao&salary_range=1&page=10">1</a>',
+            rendered_template
+        )

--- a/pyjobs/core/tests/test_templatetags.py
+++ b/pyjobs/core/tests/test_templatetags.py
@@ -7,29 +7,31 @@ class TestMergeQueryParamsTag(SimpleTestCase):
         self.rf = RequestFactory()
 
     def test_add_param(self):
-        request = self.rf.get('/', {'description': 'descricao', 'salary_range': 1})
-        context = Context({'request': request})
+        request = self.rf.get("/", {"description": "descricao", "salary_range": 1})
+        context = Context({"request": request})
         template = Template(
-            '{% load core_tags %}'
+            "{% load core_tags %}"
             '<a class="page-link" href="/?{% merge_query_params page=1 %}">1</a>'
         )
         rendered_template = template.render(context)
 
         self.assertInHTML(
             '<a class="page-link" href="/?description=descricao&salary_range=1&page=1">1</a>',
-            rendered_template
+            rendered_template,
         )
 
     def test_replace_param(self):
-        request = self.rf.get('/', {'description': 'descricao', 'salary_range': 1, 'page': 2})
-        context = Context({'request': request})
+        request = self.rf.get(
+            "/", {"description": "descricao", "salary_range": 1, "page": 2}
+        )
+        context = Context({"request": request})
         template = Template(
-            '{% load core_tags %}'
+            "{% load core_tags %}"
             '<a class="page-link" href="/?{% merge_query_params page=10 %}">1</a>'
         )
         rendered_template = template.render(context)
 
         self.assertInHTML(
             '<a class="page-link" href="/?description=descricao&salary_range=1&page=10">1</a>',
-            rendered_template
+            rendered_template,
         )


### PR DESCRIPTION
Os links da paginação estavam ignorando os parâmetros de busca enviados na url, então criei uma template tag para facilitar a manipulação desses parâmetros 