### PR TITLE
Replace pipenv references with poetry in Dockerfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ python:
 env:
   global:
     - SECRET_KEY=here-comes-a-secret-key
-    - PIPENV_IGNORE_VIRTUALENVS=1
     - CC_TEST_REPORTER_ID=d00a646dd653557dee1029960b0157368f641db4802f51c8df64ae4f6397f933
 before_install:
   - pip install -U pip

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7.4-slim
+FROM python:3.8.5-slim
 ENV PYTHONUNBUFFERED 1
 ENV SECRET_KEY here-comes-a-secret-key  # merely a mock to allow collectstatic
 
@@ -6,15 +6,15 @@ WORKDIR /code
 COPY Makefile Makefile
 COPY manage.py manage.py
 COPY .env .env
-COPY Pipfile.lock Pipfile.lock
-COPY Pipfile Pipfile
+COPY poetry.lock poetry.lock
+COPY pyproject.toml pyproject.toml
 
 RUN apt-get update && \
     apt-get install -y make && \
     rm -rf /var/lib/apt/lists/* && \
     pip install -U pip && \
-    pip install -U pipenv && \
-    pipenv install --system --deploy --ignore-pipfile --dev
+    pip install -U poetry && \
+    poetry install
 
 COPY pyjobs/ /code/pyjobs/
-RUN  python manage.py collectstatic --no-input
+RUN  poetry run python manage.py collectstatic --no-input

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ O PyJobs é o site de job listing de vagas Python no Brasil, nele você consegue
 git clone https://github.com/vmesel/PyJobs.git
 cd PyJobs/
 cp .env-sample .env
-pipenv install
+pip install poetry
 ```
 
 Para você poder subir a sua versão do PyJobs, crie um `.env` dentro da pasta PyJobs contendo as seguintes informações:
@@ -25,7 +25,7 @@ Para você poder subir a sua versão do PyJobs, crie um `.env` dentro da pasta P
 
 ```
 docker-compose build
-docker-compose run web python manage.py migrate
+docker-compose run web poetry run python manage.py migrate
 docker-compose up
 ```
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -13,5 +13,3 @@ que podemos mexer e melhorar no sistema! xD
  - [ ] Exterminar erros de code-smell que estão [aqui no CodeClimate](https://codeclimate.com/github/vmesel/PyJobs)
  - [ ] Arrumar lógicas da view de contato para remover a validação do RECAPTCHA da view e colocar no form
  - [ ] Adicionar campo de tipo de contratação (CLT, PJ, Freela, CLT ou PJ, A discutir)
- - [ ] Atualizar Dockerfile para Python 3.8
- - [ ] Atualizar Pipfile para Python 3.8

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
 
   web:
     build: .
-    command: python manage.py runserver 0.0.0.0:8000
+    command: poetry run python manage.py runserver 0.0.0.0:8000
     volumes:
       - ./:/code
     ports:


### PR DESCRIPTION
When trying to run the project the first time I was facing some issues with pipenv because it was not listing all the dependencies.

I've assumed the poetry is the package manager for the project and remove the pipenv references. This will fix the setup for newcomers and create a unique way of dealing with dependencies.

## Changes
- Remove pipenv 
- Fix Dockerfile to use Python 3.8.5
- Fix compose build to use poetry 